### PR TITLE
Make `AppNetwork---Message` consistent with `AppBuilder` API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -175,11 +175,11 @@ pub trait AppNetworkClientMessage {
     /// - Add a new event type of [`NetworkData<T>`]
     /// - Register the type for transformation over the wire
     /// - Internal bookkeeping
-    fn listen_for_client_message<T: ClientMessage>(&mut self);
+    fn listen_for_client_message<T: ClientMessage>(&mut self) -> &mut Self;
 }
 
 impl AppNetworkClientMessage for AppBuilder {
-    fn listen_for_client_message<T: ClientMessage>(&mut self) {
+    fn listen_for_client_message<T: ClientMessage>(&mut self) -> &mut Self {
         let client = self.world().get_resource::<NetworkClient>().expect("Could not find `NetworkClient`. Be sure to include the `ClientPlugin` before listening for client messages.");
 
         debug!("Registered a new ClientMessage: {}", T::NAME);
@@ -192,7 +192,7 @@ impl AppNetworkClientMessage for AppBuilder {
         client.recv_message_map.insert(T::NAME, Vec::new());
 
         self.add_event::<NetworkData<T>>();
-        self.add_system_to_stage(CoreStage::PreUpdate, register_client_message::<T>.system());
+        self.add_system_to_stage(CoreStage::PreUpdate, register_client_message::<T>.system())
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -375,11 +375,11 @@ pub trait AppNetworkServerMessage {
     /// - Add a new event type of [`NetworkData<T>`]
     /// - Register the type for transformation over the wire
     /// - Internal bookkeeping
-    fn listen_for_server_message<T: ServerMessage>(&mut self);
+    fn listen_for_server_message<T: ServerMessage>(&mut self) -> &mut Self;
 }
 
 impl AppNetworkServerMessage for AppBuilder {
-    fn listen_for_server_message<T: ServerMessage>(&mut self) {
+    fn listen_for_server_message<T: ServerMessage>(&mut self) -> &mut Self {
         let server = self.world().get_resource::<NetworkServer>().expect("Could not find `NetworkServer`. Be sure to include the `ServerPlugin` before listening for server messages.");
 
         debug!("Registered a new ServerMessage: {}", T::NAME);
@@ -391,7 +391,7 @@ impl AppNetworkServerMessage for AppBuilder {
         );
         server.recv_message_map.insert(T::NAME, Vec::new());
         self.add_event::<NetworkData<T>>();
-        self.add_system_to_stage(CoreStage::PreUpdate, register_server_message::<T>.system());
+        self.add_system_to_stage(CoreStage::PreUpdate, register_server_message::<T>.system())
     }
 }
 


### PR DESCRIPTION
This PR provides a small QoL improvement by allowing the user to chain registering `ServerMessages` (or `ClientMessages`). This is helpful when using `listen_for_XXX_message::<T>()` in for example `Plugin`s or just having a lot of different Messagetypes to initialize. It furthermore resembles the API of the `Appbuilder`, which is IMHO desirable.