### PR TITLE
Standalone network client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{error::Error, net::SocketAddr, sync::Arc};
 
 use bevy::prelude::*;
 use dashmap::DashMap;
@@ -163,6 +163,232 @@ impl NetworkClient {
     /// This may return true even if the connection has already been broken on the server side.
     pub fn is_connected(&self) -> bool {
         self.server_connection.is_some()
+    }
+}
+
+/// An instance of a [`NetworkClient`] is used to connect to a remote server
+/// using [`NetworkClient::connect`]
+pub struct StandaloneNetworkClient {
+    runtime: Runtime,
+    server_connection: Option<ServerConnection>,
+    recv_message_map: Arc<DashMap<&'static str, Vec<Box<dyn NetworkMessage>>>>,
+    network_events: SyncChannel<ClientNetworkEvent>,
+}
+
+impl std::fmt::Debug for StandaloneNetworkClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(conn) = self.server_connection.as_ref() {
+            write!(f, "NetworkClient [Connected to {}]", conn.peer_addr)?;
+        } else {
+            write!(f, "NetworkClient [Not Connected]")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl StandaloneNetworkClient {
+    pub fn new() -> Self {
+        Self {
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("Could not build tokio runtime"),
+            server_connection: None,
+            recv_message_map: Arc::new(DashMap::new()),
+            network_events: SyncChannel::new(),
+        }
+    }
+
+    /// Connect to a remote server
+    ///
+    /// ## Note
+    /// This will disconnect you first from any existing server connections
+    pub fn connect(
+        &mut self,
+        addr: impl ToSocketAddrs + Send,
+        network_settings: NetworkSettings,
+    ) -> Result<(), Box<dyn Error>> {
+        debug!("Starting connection");
+
+        self.disconnect();
+
+        let connection = self
+            .runtime
+            .block_on(async move { TcpStream::connect(addr).await })?;
+
+        let peer_addr = connection.peer_addr()?;
+
+        debug!("Connected to: {:?}", peer_addr);
+
+        let (read_socket, send_socket) = connection.into_split();
+        let recv_message_map = self.recv_message_map.clone();
+        let (send_message, recv_message) = unbounded_channel();
+        let network_event_sender = self.network_events.sender.clone();
+        let network_event_sender_two = self.network_events.sender.clone();
+
+        self.server_connection = Some(ServerConnection {
+            peer_addr,
+            send_task: self.runtime.spawn(async move {
+                let mut recv_message = recv_message;
+                let mut send_socket = send_socket;
+
+                debug!("Starting new server connection, sending task");
+
+                while let Some(message) = recv_message.recv().await {
+                    let encoded = match bincode::serialize(&message) {
+                        Ok(encoded) => encoded,
+                        Err(err) => {
+                            error!("Could not encode packet {:?}: {}", message, err);
+                            continue;
+                        }
+                    };
+
+                    let len = encoded.len();
+                    debug!("Sending a new message of size: {}", len);
+
+                    match send_socket.write_u32(len as u32).await {
+                        Ok(_) => (),
+                        Err(err) => {
+                            error!("Could not send packet length: {:?}: {}", len, err);
+                            break;
+                        }
+                    }
+
+                    trace!("Sending the content of the message!");
+
+                    match send_socket.write_all(&encoded).await {
+                        Ok(_) => (),
+                        Err(err) => {
+                            error!("Could not send packet: {:?}: {}", message, err);
+                            break;
+                        }
+                    }
+
+                    trace!("Succesfully written all!");
+                }
+
+                let _ = network_event_sender_two.send(ClientNetworkEvent::Disconnected);
+            }),
+            receive_task: self.runtime.spawn(async move {
+                let mut read_socket = read_socket;
+                let network_settings = network_settings;
+                let recv_message_map = recv_message_map;
+
+                let mut buffer: Vec<u8> =
+                    (0..network_settings.max_packet_length).map(|_| 0).collect();
+                loop {
+                    let length = match read_socket.read_u32().await {
+                        Ok(len) => len as usize,
+                        Err(err) => {
+                            error!(
+                                "Encountered error while fetching length [{}]: {}",
+                                peer_addr, err
+                            );
+                            break;
+                        }
+                    };
+
+                    if length > network_settings.max_packet_length {
+                        error!(
+                            "Received too large packet from [{}]: {} > {}",
+                            peer_addr, length, network_settings.max_packet_length
+                        );
+                        break;
+                    }
+
+                    match read_socket.read_exact(&mut buffer[..length]).await {
+                        Ok(_) => (),
+                        Err(err) => {
+                            error!(
+                                "Encountered error while fetching stream of length {} [{}]: {}",
+                                length, peer_addr, err
+                            );
+                            break;
+                        }
+                    }
+
+                    let packet: NetworkPacket = match bincode::deserialize(&buffer[..length]) {
+                        Ok(packet) => packet,
+                        Err(err) => {
+                            error!(
+                                "Failed to decode network packet from [{}]: {}",
+                                peer_addr, err
+                            );
+                            break;
+                        }
+                    };
+
+                    match recv_message_map.get_mut(&packet.kind[..]) {
+                        Some(mut packets) => packets.push(packet.data),
+                        None => {
+                            error!(
+                                "Could not find existing entries for message kinds: {:?}",
+                                packet
+                            );
+                        }
+                    }
+                    debug!("Received message from: {}", peer_addr);
+                }
+
+                let _ = network_event_sender.send(ClientNetworkEvent::Disconnected);
+            }),
+            send_message,
+        });
+
+        match self
+            .network_events
+            .sender
+            .send(ClientNetworkEvent::Connected)
+        {
+            Ok(_) => (),
+            Err(_) => {
+                error!("Could not send connected event");
+                return Err(Box::new(NetworkError::NotConnected));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Disconnect from a server
+    ///
+    /// This operation is idempotent and simply does nothing when you are
+    /// not connected to anything
+    pub fn disconnect(&mut self) {
+        if let Some(conn) = self.server_connection.take() {
+            conn.stop();
+
+            let _ = self
+                .network_events
+                .sender
+                .send(ClientNetworkEvent::Disconnected);
+        }
+    }
+
+    /// Send a message to the connected server, returns `Err(NetworkError::NotConnected)` if
+    /// the connection hasn't been established yet
+    pub fn send_message<T: ServerMessage>(&self, message: T) -> Result<(), NetworkError> {
+        debug!("Sending message to server");
+        let server_connection = match self.server_connection.as_ref() {
+            Some(server) => server,
+            None => return Err(NetworkError::NotConnected),
+        };
+
+        let packet = NetworkPacket {
+            kind: String::from(T::NAME),
+            data: Box::new(message),
+        };
+
+        match server_connection.send_message.send(packet) {
+            Ok(_) => (),
+            Err(err) => {
+                error!("Server disconnected: {}", err);
+                return Err(NetworkError::NotConnected);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -188,6 +188,7 @@ impl std::fmt::Debug for StandaloneNetworkClient {
 }
 
 impl StandaloneNetworkClient {
+    /// Create a new client
     pub fn new() -> Self {
         Self {
             runtime: tokio::runtime::Builder::new_multi_thread()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ mod server;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use bevy::{prelude::*, utils::Uuid};
-pub use client::{AppNetworkClientMessage, NetworkClient};
+pub use client::{AppNetworkClientMessage, NetworkClient, StandaloneNetworkClient};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use derive_more::{Deref, Display};
 use error::NetworkError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,11 @@ impl ConnectionId {
         self.addr
     }
 
+    /// Get the unique Uuid associated with this connection id
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
     pub(crate) fn server(addr: Option<SocketAddr>) -> ConnectionId {
         ConnectionId {
             uuid: Uuid::nil(),


### PR DESCRIPTION
This extracts the NetworkClient from b489d1700e1500ddd0911688d593fb5ecfea915f. Basically a version of NetworkClient that blocks until a connection is made.

I'll put this up there, as it works. 

However, it's probably better (if possible) to rework NetworkClient, so that it doesnt require hooking into bevy's system runtime. this is just a vague idea however, as I am not too conversant with async atm, and don't have the time to look into it properly.

Cheers for the library, its very nice!